### PR TITLE
return inAppBrowser instance from popup method

### DIFF
--- a/www/oauth.js
+++ b/www/oauth.js
@@ -124,6 +124,7 @@ module.exports = {
 			else
 				callback(new Error("unable to receive token"));
 		});
+		return wnd;
 	},
 	http: function(opts) {
 		var options = {};


### PR DESCRIPTION
Popup should return an instance of open inAppBrowser and allow to hook to it or listen for events inside of your code if needed. 
